### PR TITLE
Support Ubuntu 24 instead of 22

### DIFF
--- a/inventory
+++ b/inventory
@@ -1,5 +1,5 @@
 [remote]
-149.165.153.78 ansible_user=exouser
+derek-ofodev.bio220124.projects.jetstream-cloud.org ansible_user=exouser
 
 [local]
 127.0.0.1 ansible_user=exouser

--- a/roles/ofo/tasks/irods.yaml
+++ b/roles/ofo/tasks/irods.yaml
@@ -19,7 +19,7 @@
 - name: APT_REPOSITORY | add the irods repo
   become: true
   ansible.builtin.apt_repository:
-    repo: "deb [arch=amd64] https://packages.irods.org/apt/ focal main"
+    repo: "deb [arch=amd64] https://packages.irods.org/apt/ noble main"
     state: present
   ignore_errors: true
 

--- a/roles/ofo/tasks/main.yaml
+++ b/roles/ofo/tasks/main.yaml
@@ -16,9 +16,9 @@
     - irods.yaml
     - geograypher.yaml
     - qgis.yaml
-    - r.yaml
     - anaconda.yaml
     - metashape.yaml
+    - r.yaml
     - sublime.yaml
     - jupyter.yaml
     - rstudio_ssl.yaml
@@ -29,3 +29,13 @@
   loop:
     - setup_private_folder.yaml
   when: RUN_PRIVATE == 'yes'
+
+- name: APT ; update and upgrade system packages
+  become: true
+  apt:
+    upgrade: dist
+    update_cache: yes
+  register: apt_result
+  until: apt_result is not failed
+  retries: 2
+  delay: 10

--- a/roles/ofo/tasks/metashape.yaml
+++ b/roles/ofo/tasks/metashape.yaml
@@ -37,10 +37,26 @@
   retries: 2
   delay: 10
   
+- name: Add kisak/kisak-mesa PPA (for latest mesa drivers, desired by Metashape)
+  apt_repository:
+    repo: "ppa:kisak/kisak-mesa"
+    state: present
+    update_cache: yes
+  become: yes
+
+# required for the python module license
 - name: LINEINFILE ; ensure AGISOFT_FLS (floating license server) env var in .profile
   ansible.builtin.lineinfile:
     path: ~/.profile
     line: 'export AGISOFT_FLS={{ METASHAPE_LICENSE_SERVER_IP }}:5842'
+  
+# required for the GUI license
+- name: TEMPLATE ; template the server.lic file for Metashape floating license
+  become: true
+  template:
+    src: "server.lic.j2"
+    dest: "/opt/metashape-pro/server.lic"
+    mode: 0755
 
 - name: SHELL ; install metashape module in meta conda env
   shell:

--- a/roles/ofo/tasks/misc.yaml
+++ b/roles/ofo/tasks/misc.yaml
@@ -8,12 +8,15 @@
     path: ~/.profile
     line: 'export GPG_TTY=$(tty)'
 
-- name: APT ; install rclone and ansible
+- name: APT ; install rclone and ansible and all other misc packages
   become: true
   apt:
     pkg:
       - rclone
       - ansible-core
+      - wget
+      - ca-certificates
+      - yadm
     state: present
     update_cache: yes
   register: apt_result

--- a/roles/ofo/tasks/r.yaml
+++ b/roles/ofo/tasks/r.yaml
@@ -17,13 +17,13 @@
 - name: APT_REPOSITORY | add the r repo
   become: true
   ansible.builtin.apt_repository:
-    repo: "deb https://cloud.r-project.org/bin/linux/ubuntu jammy-cran40/"
+    repo: "deb https://cloud.r-project.org/bin/linux/ubuntu noble-cran40/"
     state: present
 
 - name: APT_REPOSITORY | add the cran repo
   become: true
   ansible.builtin.apt_repository:
-    repo: "deb [arch=amd64] https://r2u.stat.illinois.edu/ubuntu jammy main"
+    repo: "deb [arch=amd64] https://r2u.stat.illinois.edu/ubuntu noble main"
     state: present
 
 - name: APT_KEY ; add some key
@@ -38,23 +38,28 @@
     keyserver: keyserver.ubuntu.com
     id: 51716619E084DAB9
 
-- name: APT ; install ubuntu r packages
+# - name: APT ; install ubuntu r packages
+#   become: true
+#   apt:
+#     pkg:
+#       - r-base/noble-cran40
+#       - r-base-dev/noble-cran40
+#       - r-base-core/noble-cran40
+#     state: present
+#     update_cache: yes
+#     install_recommends: false
+#   register: apt_result
+#   until: apt_result is not failed
+#   retries: 2
+#   delay: 10
+  
+# Turn the above into a shell call made through ansible since Ansible does not seem able to be tols
+# which repository to get r-base from, and this is necessary because on the JS2 featured U24 image,
+# the default repository is the wrong one and doesn't have the correct version of R
+- name: SHELL ; install ubuntu r packages
   become: true
-  apt:
-    pkg:
-      - r-base
-      - r-base-dev
-      - r-base-core
-      - rclone
-      - wget
-      - ca-certificates
-    state: present
-    update_cache: yes
-    install_recommends: false
-  register: apt_result
-  until: apt_result is not failed
-  retries: 2
-  delay: 10
+  shell: apt-get install -y r-base/noble-cran40 r-base-dev/noble-cran40 r-base-core/noble-cran40
+
 
 - name: APT ; install rstudio from remote deb
   become: true
@@ -189,16 +194,23 @@
     line: 'suppressMessages(bspm::enable())'
   become: true
 
-- name: PIP ; use PIP to install radian R terminal
-  become: false
-  pip:
-    name: radian
-    state: present
+# - name: PIP ; use PIP to install radian R terminal
+#   become: false
+#   pip:
+#     name: radian
+#     state: present
+
+- name: SHELL ; install radian module in base conda env (and its gcc dependency)
+  shell:
+    cmd: "~/miniconda3/bin/conda install -y -c conda-forge gcc radian"
+    creates: /home/{{ ansible_user_id }}/miniconda3/bin/radian
+  args:
+    executable: /bin/bash
 
 - name: LINK ; put symlink to radian binary in /opt/
   become: true
   file:
-    src: "/home/{{ ansible_user_id }}/.local/bin/radian"
+    src: "/home/{{ ansible_user_id }}/miniconda3/bin/radian"
     path: /opt/radian
     state: link
 

--- a/roles/ofo/tasks/ssh_timeout.yaml
+++ b/roles/ofo/tasks/ssh_timeout.yaml
@@ -13,8 +13,8 @@
   loop_control:
     loop_var: keyval
 
-- name: restart sshd
+- name: restart ssh
   service:
-    name: sshd.service
+    name: ssh.service
     state: restarted
   become: true

--- a/roles/ofo/templates/server.lic.j2
+++ b/roles/ofo/templates/server.lic.j2
@@ -1,0 +1,3 @@
+[license_server]
+host = {{ METASHAPE_LICENSE_SERVER_IP }}
+port = 5842


### PR DESCRIPTION
Also fixes Metashape GUI floating license, slightly consolidates apt package install.

This also now installs `radian` in the base conda env, using conda, because pip now refuses to install it to the global environment.